### PR TITLE
[MQ-3013] Fixing duplicated beans creation

### DIFF
--- a/src/main/java/com/mulesoft/runtime/services/analytics/integration/service/AnalyticsClient.java
+++ b/src/main/java/com/mulesoft/runtime/services/analytics/integration/service/AnalyticsClient.java
@@ -16,7 +16,6 @@ import javax.inject.Named;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-@Named
 public class AnalyticsClient {
 
     private AnalyticsQueryClient queryClient;

--- a/src/main/java/com/mulesoft/runtime/services/analytics/integration/service/AnalyticsIngestClient.java
+++ b/src/main/java/com/mulesoft/runtime/services/analytics/integration/service/AnalyticsIngestClient.java
@@ -19,7 +19,6 @@ import rx.Observable;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-@Named
 public class AnalyticsIngestClient {
 
     private static final String EMPTY_BODY = "";

--- a/src/main/java/com/mulesoft/runtime/services/analytics/integration/service/MetricsIngestService.java
+++ b/src/main/java/com/mulesoft/runtime/services/analytics/integration/service/MetricsIngestService.java
@@ -41,7 +41,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
-@Named
 public class MetricsIngestService {
 
     private static final long CACHE_SIZE = 16384;

--- a/src/main/java/com/mulesoft/runtime/services/analytics/integration/subscriber/AnalyticsNotificationSubscriber.java
+++ b/src/main/java/com/mulesoft/runtime/services/analytics/integration/subscriber/AnalyticsNotificationSubscriber.java
@@ -19,7 +19,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.concurrent.Executors;
 
-@Named
 public class AnalyticsNotificationSubscriber extends AbstractNotificationSubscriber {
 
     private String analyticsSenderId;

--- a/src/main/java/com/mulesoft/runtime/services/analytics/integration/subscriber/SegmentNotificationSubscriber.java
+++ b/src/main/java/com/mulesoft/runtime/services/analytics/integration/subscriber/SegmentNotificationSubscriber.java
@@ -17,7 +17,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.concurrent.Executors;
 
-@Named
 public class SegmentNotificationSubscriber extends AbstractNotificationSubscriber {
 
 


### PR DESCRIPTION
This repo is intended to be a spring boot starter, hence it has the autoconfiguration logic. 

The problem is that we are also using the `@Named` annotations on some objects. This is leading to have two objects instantiated when using both autoconfiguration and scanning other packages using the `@ComponentScan` in a Spring Boot project. 

We are basically creating this objects twice when doing so. And this is making tests fails. This wasn't failing before because we never needed to add a new `@ComponentScan` for a different class than the one we use in OSv2. But as part of a new library we added under `com.mulesoft.runtime.services` package we are adding that package to the `@ComponentScan` and hence we are creating objects twice (autoconfiguration and named ones) in OSv2