### PR TITLE
[W-10811001] Analytics ingestion on cache full

### DIFF
--- a/src/main/java/com/mulesoft/runtime/services/analytics/integration/autoconfiguration/AnalyticsAutoConfiguration.java
+++ b/src/main/java/com/mulesoft/runtime/services/analytics/integration/autoconfiguration/AnalyticsAutoConfiguration.java
@@ -81,7 +81,7 @@ public class AnalyticsAutoConfiguration {
     @ConditionalOnMissingBean(HttpClient.class)
     @ConditionalOnProperty(value = "analytics.subscription.enabled", havingValue = "true")
     public HttpClient objectStoreDefaultHttpClient(@Value("${http.client.insecure:false}") boolean insecure,
-                                                   @Value("${http.client.timeout:20000}") int timeout) {
+                                                   @Value("${http.client.timeout:60000}") int timeout) {
         return new HttpClient.Builder().setInsecure(insecure).setTimeout(timeout).build();
     }
 

--- a/src/main/java/com/mulesoft/runtime/services/analytics/integration/autoconfiguration/AnalyticsAutoConfiguration.java
+++ b/src/main/java/com/mulesoft/runtime/services/analytics/integration/autoconfiguration/AnalyticsAutoConfiguration.java
@@ -48,7 +48,7 @@ public class AnalyticsAutoConfiguration {
                                                      @Value("${analytics.ingest.granularity}") int granularity,
                                                      @Value("${analytics.ingest.period}") int period,
                                                      @Value("${analytics.ingest.poolSize:8}") int poolSize,
-                                                     @Value("${analytics.ingest.cache.size:2048}") long cacheSize) {
+                                                     @Value("${analytics.ingest.cacheSize:2048}") long cacheSize) {
         return new MetricsIngestService(anypointAnalyticsClient, writekey, analyticsSenderId, granularity, period, poolSize, cacheSize);
     }
 

--- a/src/main/java/com/mulesoft/runtime/services/analytics/integration/autoconfiguration/AnalyticsAutoConfiguration.java
+++ b/src/main/java/com/mulesoft/runtime/services/analytics/integration/autoconfiguration/AnalyticsAutoConfiguration.java
@@ -47,8 +47,9 @@ public class AnalyticsAutoConfiguration {
                                                      @Value("${analytics.senderId}") String analyticsSenderId,
                                                      @Value("${analytics.ingest.granularity}") int granularity,
                                                      @Value("${analytics.ingest.period}") int period,
-                                                     @Value("${analytics.ingest.poolSize:8}") int poolSize) {
-        return new MetricsIngestService(anypointAnalyticsClient, writekey, analyticsSenderId, granularity, period, poolSize);
+                                                     @Value("${analytics.ingest.poolSize:8}") int poolSize,
+                                                     @Value("${analytics.ingest.cache.size:2048}") long cacheSize) {
+        return new MetricsIngestService(anypointAnalyticsClient, writekey, analyticsSenderId, granularity, period, poolSize, cacheSize);
     }
 
     @Bean

--- a/src/main/java/com/mulesoft/runtime/services/analytics/integration/autoconfiguration/AnalyticsAutoConfiguration.java
+++ b/src/main/java/com/mulesoft/runtime/services/analytics/integration/autoconfiguration/AnalyticsAutoConfiguration.java
@@ -81,7 +81,7 @@ public class AnalyticsAutoConfiguration {
     @ConditionalOnMissingBean(HttpClient.class)
     @ConditionalOnProperty(value = "analytics.subscription.enabled", havingValue = "true")
     public HttpClient objectStoreDefaultHttpClient(@Value("${http.client.insecure:false}") boolean insecure,
-                                                   @Value("${http.client.timeout:60000}") int timeout) {
+                                                   @Value("${http.client.timeout:20000}") int timeout) {
         return new HttpClient.Builder().setInsecure(insecure).setTimeout(timeout).build();
     }
 

--- a/src/main/java/com/mulesoft/runtime/services/analytics/integration/service/MetricsIngestService.java
+++ b/src/main/java/com/mulesoft/runtime/services/analytics/integration/service/MetricsIngestService.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 
 public class MetricsIngestService {
 
-    private static final long CACHE_SIZE = 2048;
+    private long cacheSize;
 
     private static Analytics segment;
 
@@ -75,11 +75,12 @@ public class MetricsIngestService {
                                 @Value("${analytics.senderId}") String analyticsSenderId,
                                 @Value("${analytics.ingest.granularity}") int granularity,
                                 @Value("${analytics.ingest.period}") int period,
-                                @Value("${analytics.ingest.poolSize:8}") int poolSize) {
+                                @Value("${analytics.ingest.poolSize:8}") int poolSize,
+                                @Value("${analytics.ingest.cacheSize:2048}") long cacheSize) {
         this.analyticsSenderId = analyticsSenderId;
 
         this.metricsCache = CacheBuilder.newBuilder()
-                .maximumSize(CACHE_SIZE)
+                .maximumSize(cacheSize)
                 .build(
                         new CacheLoader<MetricsKey, MetricsCounts>() {
                             @Override
@@ -100,6 +101,8 @@ public class MetricsIngestService {
         this.granularity = granularity;
 
         this.period = period;
+
+        this.cacheSize = cacheSize;
 
         updateNextFlushTime();
     }
@@ -177,7 +180,7 @@ public class MetricsIngestService {
             if (logger.isDebugEnabled()) {
                 logger.debug("metrics updated for key {}, notificationCount {}, billableUnitCount {}, byteCount {}", key, count, billableUnitCount, byteCount);
             }
-            if(metricsCache.size() >= CACHE_SIZE && getSecondsUntilNextFlush() > 0) {
+            if(metricsCache.size() >= cacheSize && getSecondsUntilNextFlush() > 0) {
                 flush();
                 updateNextFlushTime();
             }

--- a/src/main/java/com/mulesoft/runtime/services/analytics/integration/service/MetricsIngestService.java
+++ b/src/main/java/com/mulesoft/runtime/services/analytics/integration/service/MetricsIngestService.java
@@ -180,7 +180,7 @@ public class MetricsIngestService {
             if (logger.isDebugEnabled()) {
                 logger.debug("metrics updated for key {}, notificationCount {}, billableUnitCount {}, byteCount {}", key, count, billableUnitCount, byteCount);
             }
-            if(metricsCache.size() >= cacheSize && getSecondsUntilNextFlush() > 0) {
+            if(metricsCache.size() == cacheSize && getSecondsUntilNextFlush() > 0) {
                 flush();
                 updateNextFlushTime();
             }

--- a/src/main/java/com/mulesoft/runtime/services/analytics/integration/service/MetricsIngestService.java
+++ b/src/main/java/com/mulesoft/runtime/services/analytics/integration/service/MetricsIngestService.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 
 public class MetricsIngestService {
 
-    private static final long CACHE_SIZE = 16384;
+    private static final long CACHE_SIZE = 2048;
 
     private static Analytics segment;
 
@@ -176,6 +176,10 @@ public class MetricsIngestService {
             counts.getByteCount().add(byteCount);
             if (logger.isDebugEnabled()) {
                 logger.debug("metrics updated for key {}, notificationCount {}, billableUnitCount {}, byteCount {}", key, count, billableUnitCount, byteCount);
+            }
+            if(metricsCache.size() >= CACHE_SIZE && getSecondsUntilNextFlush() > 0) {
+                flush();
+                updateNextFlushTime();
             }
         } catch (ExecutionException e) {
             logger.error("instance {} encountered an error while trying to update its metrics cache: {}", analyticsSenderId, e);


### PR DESCRIPTION
With this PR we want to achieve 2 things:
1. Add implementation to support flush metrics when the metrics cache is full.
2. Reduce the cache size to reduce the amount of data we flush to metrics ingestion. (right now we are ingesting about 8Mb-10Mb per second, which analytics wants us to reduce to 1Mb per sec. Hence, I have reduced the cache size by 8 times).

